### PR TITLE
Modified - Updated ACR template to disable public access

### DIFF
--- a/simple-landing-zone/templates/shared/deploy-acr.json
+++ b/simple-landing-zone/templates/shared/deploy-acr.json
@@ -43,6 +43,7 @@
                 "tier": "Premium"
             },
             "properties": {
+                "publicNetworkAccess": "Disabled"
             }
         },
         {


### PR DESCRIPTION
* Modified ACR template to disable public access. ACR does not disable public access by default when a Private Endpoint is added.